### PR TITLE
Relax constraints on input X: Allow NaNs

### DIFF
--- a/ngboost/ngboost.py
+++ b/ngboost/ngboost.py
@@ -338,7 +338,7 @@ class NGBoost:
             raise ValueError("y cannot be None")
 
         X, Y = check_X_y(
-            X, Y, accept_sparse=True, y_numeric=True, multi_output=self.multi_output
+            X, Y, accept_sparse=True, y_numeric=True, multi_output=self.multi_output, force_all_finite='allow-nan'
         )
 
         self.n_features = X.shape[1]


### PR DESCRIPTION
This change suggests to add the `'allow-nan'` parameter in the `check_X_y` function from `scikit-learn`. Its fully compatible with the API, as well as backward compatible for all users which have been using NGBoost for their prediction tasks.